### PR TITLE
Allow user to pass in otherOptions object with params from aws-sdk

### DIFF
--- a/src/Deployer.ts
+++ b/src/Deployer.ts
@@ -27,6 +27,8 @@ export interface IDeployerOptions {
   maxAge?: number; // for everything except revved assets
 
   assetsPrefix?: string; // e.g. "https://example.com/v2/__assets/"
+
+  otherOptions?: object; // pass in any other params that aws-sdk supports
 }
 
 interface IRevManifest {
@@ -54,7 +56,8 @@ export default class Deployer extends EventEmitter {
       targets,
       preview,
       assetsPrefix,
-      maxAge
+      maxAge,
+      otherOptions,
     } = this.options;
 
     // load in the rev-manifest
@@ -111,7 +114,8 @@ export default class Deployer extends EventEmitter {
                 Body: readFileSync(filePath as string),
                 Bucket: bucketName,
                 CacheControl: "max-age=365000000, immutable",
-                Key: `v2/__assets/${projectName}/${filename}`
+                Key: `v2/__assets/${projectName}/${filename}`,
+                ...otherOptions,
               })
               .promise()
           )
@@ -141,7 +145,8 @@ export default class Deployer extends EventEmitter {
                     : mime(extname(filename as string)) || undefined,
                 Key: `v2${
                   preview ? "-preview" : ""
-                }/${projectName}/${target}/${filename}`
+                }/${projectName}/${target}/${filename}`,
+                ...otherOptions,
               })
               .promise()
           )
@@ -161,7 +166,8 @@ export default class Deployer extends EventEmitter {
             ContentType: "application/json",
             Key: `v2${
               preview ? "-preview" : ""
-            }/${projectName}/${target}/${REV_MANIFEST_FILENAME}`
+            }/${projectName}/${target}/${REV_MANIFEST_FILENAME}`,
+            ...otherOptions,
           })
           .promise()
           .then(() =>

--- a/test/Deployer.spec.ts
+++ b/test/Deployer.spec.ts
@@ -32,7 +32,12 @@ describe("Deployer class", () => {
       bucketName: "test-bucket",
       localDir: resolve(__dirname, "..", "fixture", "dist"),
       projectName: "test-project",
-      targets: ["test"]
+      targets: ["test"],
+      otherOptions: {
+        Metadata: {
+          'x-amz-meta-surrogate-key': 'my-key',
+        },
+      },
     });
   });
 
@@ -62,7 +67,8 @@ describe("Deployer class", () => {
         ),
         Bucket: "test-bucket",
         CacheControl: "max-age=365000000, immutable",
-        Key: `v2/__assets/test-project/foo.abc123.js`
+        Key: `v2/__assets/test-project/foo.abc123.js`,
+        Metadata: { 'x-amz-meta-surrogate-key': "my-key" }
       });
       putObjectStub.should.have.been.calledWith({
         ACL: "public-read",
@@ -72,7 +78,8 @@ describe("Deployer class", () => {
         Bucket: "test-bucket",
         CacheControl: "max-age=60",
         ContentType: "application/javascript",
-        Key: `v2/test-project/test/foo.abc123.js`
+        Key: `v2/test-project/test/foo.abc123.js`,
+        Metadata: { 'x-amz-meta-surrogate-key': "my-key" }
       });
       putObjectStub.should.have.been.calledWith({
         ACL: "public-read",
@@ -82,7 +89,8 @@ describe("Deployer class", () => {
         Bucket: "test-bucket",
         CacheControl: "max-age=60",
         ContentType: "text/html",
-        Key: `v2/test-project/test/index.html`
+        Key: `v2/test-project/test/index.html`,
+        Metadata: { 'x-amz-meta-surrogate-key': "my-key" }
       });
       putObjectStub.should.have.been.calledWith({
         ACL: "public-read",
@@ -90,7 +98,8 @@ describe("Deployer class", () => {
         Bucket: "test-bucket",
         CacheControl: "max-age=60",
         ContentType: "application/json",
-        Key: "v2/test-project/test/rev-manifest.json"
+        Key: "v2/test-project/test/rev-manifest.json",
+        Metadata: { 'x-amz-meta-surrogate-key': "my-key" }
       });
     });
   });


### PR DESCRIPTION
Will allow us to add Metadata to files, which could include headers that we can turn into surrogate key headers.